### PR TITLE
Fix Docker build DNS failure for Intel GPU repository

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,6 +47,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      network: host          # Use host DNS so Intel GPU repo resolves during build
       args:
         OLLAMA_VERSION: ${OLLAMA_VERSION:-latest}
     image: olama:${OLLAMA_VERSION:-latest}


### PR DESCRIPTION
Add `network: host` to the olama build config so that all RUN steps (Intel GPG key download, apt-get update, package install) resolve repositories.intel.com using the host's DNS stack instead of Docker's isolated build network, which lacks the necessary resolver configuration.

Without this, the build fails with "Could not resolve 'repositories.intel.com'" on the intel-opencl-icd / libze1 / libze-intel-gpu1 / intel-ocloc install step.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6