### PR TITLE
Fix Ollama install: multi-stage build from Docker Hub instead of GitH…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,21 @@
 # Ollama with Intel GPU support (minimal - no model bundled)
-# Supports Intel Arc, Intel Iris Xe, and Intel integrated graphics via oneAPI/SYCL
+# Supports Intel Arc, Intel Iris Xe, and Intel integrated graphics via Level Zero
 # Models are downloaded at runtime via pull-model.sh or the Ollama API
 
+# =============================================================================
+# Stage 1 — Fetch the official Ollama binary from Docker Hub.
+#
+# This avoids the GitHub releases CDN entirely. GitHub CDN returns 404 in
+# environments that restrict external downloads, and Ollama's release artifact
+# names have changed across versions making direct URL construction fragile.
+# Docker Hub is the most universally accessible source.
+# =============================================================================
+ARG OLLAMA_VERSION=latest
+FROM ollama/ollama:${OLLAMA_VERSION} AS ollama-bin
+
+# =============================================================================
+# Stage 2 — Ubuntu 22.04 + Intel GPU compute runtime
+# =============================================================================
 FROM ubuntu:22.04
 
 ARG OLLAMA_VERSION=latest
@@ -9,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     OLLAMA_HOST=0.0.0.0:11434 \
     OLLAMA_MODELS=/root/.ollama/models
 
-# Install Intel GPU runtime and OpenCL support
+# Install base tools (wget/gpg needed for Intel repo key)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
@@ -18,19 +32,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Add Intel graphics repository for GPU driver support
+# Add Intel GPU repository
 RUN wget -qO- https://repositories.intel.com/gpu/intel-graphics.key \
     | gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg \
   && echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy unified" \
     | tee /etc/apt/sources.list.d/intel-gpu-jammy.list
 
 # Install Intel GPU compute runtime (OpenCL + Level Zero)
-# intel-opencl-icd  — OpenCL ICD for all Intel GPU generations
-# libze1            — Level Zero loader (Arc / Xe / 10th-gen+ iGPU)
+# intel-opencl-icd  — OpenCL ICD for all Intel GPU generations (4th gen+)
+# libze1            — Level Zero loader (10th-gen+ iGPU, Arc dGPU)
 # libze-intel-gpu1  — Level Zero GPU driver
-# intel-ocloc       — OpenCL offline compiler; required for Gen 9-12 iGPU and Arc
-#                     (without it, kernels are JIT-compiled per-run which can hang
-#                      or fail on first inference for these GPU generations)
+# intel-ocloc       — OpenCL offline compiler; without it Gen 9-12 / Arc GPUs
+#                     JIT-compile kernels on every cold start, which can hang
 # clinfo            — diagnostic: lists detected OpenCL/Level Zero devices
 RUN apt-get update && apt-get install -y --no-install-recommends \
     intel-opencl-icd \
@@ -40,20 +53,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     clinfo \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Ollama binary from GitHub releases.
-# We download the standalone binary (no .tgz) because:
-#   • Ollama no longer ships ollama-linux-amd64.tgz in recent releases
-#   • Intel GPU acceleration uses Level Zero (installed above via apt),
-#     so no bundled CUDA/ROCm GPU libraries from a tarball are needed
-RUN if [ "${OLLAMA_VERSION}" = "latest" ]; then \
-      OLLAMA_URL="https://github.com/ollama/ollama/releases/latest/download/ollama-linux-amd64"; \
-    else \
-      OLLAMA_URL="https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64"; \
-    fi \
-    && curl -fsSL "${OLLAMA_URL}" -o /usr/local/bin/ollama \
-    && chmod +x /usr/local/bin/ollama
+# Copy Ollama from the official Docker Hub image.
+# The binary location has varied across Ollama versions; we probe both
+# /bin/ollama (used in some releases) and /usr/local/bin/ollama and take
+# whichever exists. Runner libraries (used for CUDA/ROCm) are also copied
+# when present — not required for Intel GPU (drivers come from apt above)
+# but included so the image stays compatible with CPU-only fallback.
+RUN --mount=type=bind,from=ollama-bin,source=/,target=/ollama-src \
+    OLLAMA_BIN=$(find /ollama-src/bin /ollama-src/usr/local/bin \
+                      -maxdepth 1 -name ollama -type f 2>/dev/null | head -1) \
+    && if [ -z "${OLLAMA_BIN}" ]; then \
+         echo "ERROR: ollama binary not found in official image" >&2; exit 1; \
+       fi \
+    && cp "${OLLAMA_BIN}" /usr/local/bin/ollama \
+    && chmod +x /usr/local/bin/ollama \
+    && if [ -d /ollama-src/usr/local/lib/ollama ]; then \
+         mkdir -p /usr/local/lib/ollama; \
+         cp -r /ollama-src/usr/local/lib/ollama/. /usr/local/lib/ollama/; \
+       fi
 
-# Create model directory (empty - models pulled at runtime)
+# Create model storage directory (empty — models pulled at runtime)
 RUN mkdir -p /root/.ollama/models
 
 VOLUME ["/root/.ollama"]


### PR DESCRIPTION
…ub CDN

GitHub releases CDN returns 404 for both ollama-linux-amd64.tgz and the standalone binary in this build environment, and the official install.sh has the same problem (it also downloads from GitHub CDN).

Switch to a two-stage build:
  Stage 1: FROM ollama/ollama:${OLLAMA_VERSION} — pulls the official image
           from Docker Hub, which is universally accessible
  Stage 2: Ubuntu 22.04 + Intel GPU packages (unchanged)
           Binary is copied out of stage 1 using a RUN --mount probe that
           handles both /bin/ollama and /usr/local/bin/ollama path variants
           across Ollama versions. Runner libraries (/usr/local/lib/ollama/)
           are also copied when present for CPU-fallback compatibility.

Intel GPU acceleration is unaffected — it goes through Level Zero (installed via apt), not through any bundled GPU library from the Ollama image.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6