### PR TITLE
Fix Ollama binary not found in official image during Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,8 +60,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # when present — not required for Intel GPU (drivers come from apt above)
 # but included so the image stays compatible with CPU-only fallback.
 RUN --mount=type=bind,from=ollama-bin,source=/,target=/ollama-src \
-    OLLAMA_BIN=$(find /ollama-src/bin /ollama-src/usr/local/bin \
-                      -maxdepth 1 -name ollama -type f 2>/dev/null | head -1) \
+    OLLAMA_BIN=$(find /ollama-src -name ollama -maxdepth 6 \
+                      \( -type f -o -type l \) 2>/dev/null | head -1) \
     && if [ -z "${OLLAMA_BIN}" ]; then \
          echo "ERROR: ollama binary not found in official image" >&2; exit 1; \
        fi \


### PR DESCRIPTION
The previous find command restricted search to /ollama-src/bin and /ollama-src/usr/local/bin with -type f. Two problems:

1. In Debian-based images (which Ollama uses), /bin is a symlink to usr/bin. When bind-mounting the image filesystem at /ollama-src, /ollama-src/bin is an absolute symlink resolving to the HOST /usr/bin, not /ollama-src/usr/bin — so the directory appears empty.

2. -type f excludes symlinked executables, which some image builds use.

Fix: search the entire mounted filesystem with -maxdepth 6 and match both regular files and symlinks.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6