### PR TITLE
Fix model-manager install: build locally instead of pull

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -360,10 +360,14 @@ cd "$DOCKER_DIR"
 COMPOSE_ANSI=never $COMPOSE_CMD build --pull --progress plain olama
 success "Intel GPU image built."
 
-# ── Pull any missing public images ────────────────────────────────────────────
+# ── Pull public images / build local images ───────────────────────────────────
+# Services with a registry image use `compose pull`.
+# Services built from a local Dockerfile use `compose build`.
 sep
 info "Checking service containers..."
-for svc in open-webui searxng pipelines dozzle model-manager; do
+
+# Public registry images
+for svc in open-webui searxng pipelines dozzle; do
   cname="olama-${svc}"
   if $RECREATE_CONTAINERS; then
     info "  $cname — --recreate set, pulling latest image..."
@@ -374,6 +378,22 @@ for svc in open-webui searxng pipelines dozzle model-manager; do
   else
     info "  $cname — not found, pulling image..."
     COMPOSE_ANSI=never $COMPOSE_CMD pull "$svc"
+    success "  $cname image ready."
+  fi
+done
+
+# Locally-built images (no registry — must use build, not pull)
+for svc in model-manager; do
+  cname="olama-${svc}"
+  if $RECREATE_CONTAINERS; then
+    info "  $cname — --recreate set, rebuilding image..."
+    COMPOSE_ANSI=never $COMPOSE_CMD build --progress plain "$svc"
+    success "  $cname image ready."
+  elif docker image inspect "olama-${svc}:latest" &>/dev/null; then
+    info "  $cname — image already built, skipping"
+  else
+    info "  $cname — not found, building image..."
+    COMPOSE_ANSI=never $COMPOSE_CMD build --progress plain "$svc"
     success "  $cname image ready."
   fi
 done

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -63,19 +63,26 @@ fi
 
 echo ""
 
-# ── Pull new images ───────────────────────────────────────────────────────────
+# ── Pull registry images / rebuild local images ───────────────────────────────
+# model-manager is built from a local Dockerfile — skip pull, go straight to build.
+REGISTRY_SERVICES=()
 for svc in "${SERVICES[@]}"; do
-  info "Pulling latest image for: ${svc}"
-  COMPOSE_ANSI=never $COMPOSE pull "$svc" 2>&1 \
-    | grep -v "^#" \
-    | sed 's/^/  /'
-  success "${svc} — image ready."
-  echo ""
+  [[ "$svc" == "model-manager" ]] && continue
+  REGISTRY_SERVICES+=("$svc")
 done
 
-# ── Rebuild model-manager (local Dockerfile) ─────────────────────────────────
-# The model-manager is built locally, so pull alone isn't enough — rebuild it
-# so any changes to the Dockerfile or source are applied.
+if [[ ${#REGISTRY_SERVICES[@]} -gt 0 ]]; then
+  for svc in "${REGISTRY_SERVICES[@]}"; do
+    info "Pulling latest image for: ${svc}"
+    COMPOSE_ANSI=never $COMPOSE pull "$svc" 2>&1 \
+      | grep -v "^#" \
+      | sed 's/^/  /'
+    success "${svc} — image ready."
+    echo ""
+  done
+fi
+
+# model-manager is always rebuilt (local Dockerfile)
 info "Rebuilding model-manager image..."
 COMPOSE_ANSI=never $COMPOSE build --pull --no-cache --progress plain model-manager \
   | grep -v "^#" \


### PR DESCRIPTION
model-manager uses a local Dockerfile so docker compose pull fails with "pull access denied". Split the service loop in install.sh into registry services (pull) and local-build services (compose build). Apply the same fix in update.sh — skip pull for model-manager, always build it.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6