### PR TITLE
Add unified portal: Chat, Models, and Logs in one browser tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Run [Ollama](https://ollama.com) in Docker with Intel GPU acceleration.
 Supports **Intel Arc**, **Iris Xe**, and **integrated Intel graphics** via Intel's oneAPI runtime.
 
-> **No models are bundled.** After starting, open the **Model Manager** at `http://localhost:45214` to search, download, and delete models from your browser — no CLI needed.
+> **Unified portal at `http://localhost:45200`** — Chat, Model Manager, and Log Viewer all in one browser tab. No model is bundled; open the **Models** tab to download one.
 
 ---
 
@@ -11,6 +11,7 @@ Supports **Intel Arc**, **Iris Xe**, and **integrated Intel graphics** via Intel
 
 | Container | Service | Purpose | Port |
 |---|---|---|---|
+| `olama-portal` | `portal` | **Unified web portal** — Chat, Models, and Logs in one tab | `45200` |
 | `olama` | `olama` | Ollama LLM engine — Intel GPU passthrough | `11434` |
 | `olama-open-webui` | `open-webui` | Browser chat UI | `45213` |
 | `olama-model-manager` | `model-manager` | Model search, download, and delete UI | `45214` |
@@ -19,6 +20,8 @@ Supports **Intel Arc**, **Iris Xe**, and **integrated Intel graphics** via Intel
 | `olama-dozzle` | `dozzle` | Real-time web log viewer for all containers | `9999` |
 
 All containers carry the `olama-` prefix so they are easy to identify in `docker ps` alongside other stacks.
+
+**The portal is the recommended bookmark.** Open `http://localhost:45200` once and you can reach Chat, Models, and Logs from the top nav without switching tabs or ports. Each service is still accessible directly on its own port if you prefer.
 
 **Containers are never recreated by default.** On re-runs the installer skips any container that already exists — your settings and history are never disturbed. Pass `--recreate` to force a fresh rebuild of every container.
 
@@ -40,7 +43,7 @@ All data is stored under a single configurable `DATA_DIR` on the host — no ano
 
 ## Method 1 — One-Command Installer
 
-The fastest way to get the full stack running. Clones the repo, installs Docker if needed, builds the Intel GPU image, creates data directories, writes a `.env`, and starts all 6 containers. Safe to run over SSH — closing the terminal will not stop the install.
+The fastest way to get the full stack running. Clones the repo, installs Docker if needed, builds the Intel GPU image, creates data directories, writes a `.env`, and starts all 7 containers. Safe to run over SSH — closing the terminal will not stop the install.
 
 **Step 1 — Run the installer**
 
@@ -58,7 +61,7 @@ The installer will:
 6. Open the four host-facing ports in ufw or firewalld for LAN access
 7. Build the Ollama Intel GPU image (~5 min first run — installs Intel oneAPI drivers)
 8. Pull images for any containers that do not already exist; skip existing ones
-9. Start all 6 containers
+9. Start all 7 containers
 10. Wait until Ollama and Open WebUI are healthy
 
 The installer is **idempotent** — safe to re-run after an upgrade or a failed run. It updates ports and GPU group IDs in an existing `.env` without touching your custom settings (API keys, model names, feature flags, etc.).
@@ -71,9 +74,11 @@ tail -f /tmp/olama-install.log
 
 **Step 2 — Download a model**
 
-No model is bundled — download one after the stack is running. The easiest way is the Model Manager web UI:
+No model is bundled — download one after the stack is running. The easiest way is the unified portal:
 
-Open **http://localhost:45214** — browse the catalog, filter by category, and click **Download**.
+Open **http://localhost:45200** → click the **Models** tab — browse the catalog, filter by category, and click **Download**.
+
+Or go directly to the Model Manager at **http://localhost:45214**.
 
 Or from the CLI:
 
@@ -86,18 +91,19 @@ docker exec olama ollama pull mistral
 docker exec olama ollama pull llama3.2:3b
 ```
 
-**Step 3 — Open the chat UI**
+**Step 3 — Open the portal**
 
-Open **http://localhost:45213** and select the model you pulled.
+Open **http://localhost:45200** — the unified portal loads with Chat, Models, and Logs all accessible from the top nav bar. Bookmark this single URL.
 
 To access from another device on the same network, use the host's IP — the installer prints it at the end:
 
 ```
 From other devices on your network:
-  Chat UI        →  http://192.168.x.x:45213
-  Model Manager  →  http://192.168.x.x:45214
-  Ollama API     →  http://192.168.x.x:11434
-  Log viewer     →  http://192.168.x.x:9999
+  Portal (all-in-one) →  http://192.168.x.x:45200   ← bookmark this
+  Chat UI             →  http://192.168.x.x:45213
+  Model Manager       →  http://192.168.x.x:45214
+  Ollama API          →  http://192.168.x.x:11434
+  Log viewer          →  http://192.168.x.x:9999
 ```
 
 ---
@@ -183,9 +189,9 @@ docker exec olama ollama pull mistral
 bash scripts/pull-model.sh
 ```
 
-**Step 5 — Open the chat UI**
+**Step 5 — Open the portal**
 
-Open **http://localhost:45213**.
+Open **http://localhost:45200** for the unified portal (Chat + Models + Logs in one tab), or go directly to **http://localhost:45213** for just the chat UI.
 
 ---
 
@@ -293,6 +299,34 @@ docker exec olama ollama run mistral "hello"
 
 ---
 
+## Unified Portal
+
+The **portal** at `http://localhost:45200` is a lightweight nginx container that wraps all three web interfaces into a single browser tab.
+
+```
+┌─────────────────────────────────────────────┐
+│  Olama Stack  [ Chat ]  [ Models ]  [ Logs ] │  ← 48 px dark nav bar
+├─────────────────────────────────────────────┤
+│                                             │
+│   Active service displayed here via iframe  │
+│                                             │
+└─────────────────────────────────────────────┘
+```
+
+- **Chat** — Open WebUI (port 45213)
+- **Models** — Model Manager (port 45214)
+- **Logs** — Dozzle real-time log viewer (port 9999)
+
+**State is preserved** — switching tabs does not reload the iframe, so your open chat conversation and scroll position survive.
+
+**↗ Open in new tab** — each nav button has a small external-link icon to pop the service out full-screen.
+
+**Status badge** — the top-right corner shows the number of installed models and whether the stack is healthy, polled every 30 seconds.
+
+**Works on any hostname** — the portal resolves service URLs from `window.location.hostname`, so `localhost`, a LAN IP, and a hostname like `boris.local` all work without reconfiguration.
+
+---
+
 ## Model Manager
 
 The **Model Manager** at `http://localhost:45214` lets you:
@@ -366,7 +400,12 @@ Copy `runtipi/apps/olama-intel-gpu/` into your Runtipi `apps/` directory and ref
 Olama-intelgpu/
 ├── docker/
 │   ├── Dockerfile               # Ollama + Intel oneAPI GPU drivers
-│   ├── docker-compose.yml       # Full stack: olama + open-webui + model-manager + searxng + pipelines + dozzle
+│   ├── docker-compose.yml       # Full stack: portal + olama + open-webui + model-manager + searxng + pipelines + dozzle
+│   ├── portal/
+│   │   ├── Dockerfile           # nginx:alpine + gettext (envsubst)
+│   │   ├── nginx.conf           # Static file server on port 8080
+│   │   ├── entrypoint.sh        # Injects port vars into HTML template at container start
+│   │   └── index.html.template  # Single-page portal shell (iframes + dark nav)
 │   ├── model-manager/
 │   │   ├── Dockerfile           # Python 3.11 slim + FastAPI
 │   │   ├── main.py              # API proxy + model catalog

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@
 # │                  data: ${DATA_DIR}/models   (can grow to 100+ GB)       │
 # ├─────────────────────────────────────────────────────────────────────────┤
 # │  CATEGORY: INTERFACE                                                    │
+# │    portal          — Unified entry point: Chat+Models+Logs in one page  │
+# │                      (port 45200)  stateless — no data directory needed │
 # │    open-webui      — Browser chat UI connected to olama  (port 45213)   │
 # │                      data: ${DATA_DIR}/webui  (chat history, docs, RAG) │
 # │    model-manager   — Model search, download, delete UI   (port 45214)   │
@@ -452,6 +454,66 @@ services:
         max-size: "${LOG_MAX_SIZE:-10m}"
         max-file: "${LOG_MAX_FILES:-5}"
         tag: "model-manager"
+
+    networks:
+      - olama_net
+
+# =============================================================================
+#  CATEGORY: INTERFACE — PORTAL
+#  Purpose : Single unified entry point for all web interfaces.
+#            One address, one page — Chat / Models / Logs are accessible via
+#            a top navbar without leaving the browser tab.  Switching panels
+#            keeps state (open chat, scroll position) by hiding/showing the
+#            iframes rather than reloading them.
+#  Port    : 45200 → http://localhost:45200  (the recommended bookmark)
+#  Data    : none (static HTML shell, ports injected at startup via envsubst)
+# =============================================================================
+
+  portal:
+    <<: *internet-dns
+    build:
+      context: ./portal
+      dockerfile: Dockerfile
+    image: olama-portal:latest
+    container_name: olama-portal
+    restart: unless-stopped
+    # Portal is purely a static page — it can start before the services it
+    # frames; the iframes show a spinner until each service responds.
+    depends_on:
+      - open-webui
+      - model-manager
+      - dozzle
+
+    labels:
+      com.olama.category: "interface"
+      com.olama.description: "Unified portal — single entry point for Chat, Models, and Logs"
+      com.olama.data: "none"
+      com.olama.log: "none"
+
+    ports:
+      - "${PORTAL_PORT:-45200}:8080"
+
+    environment:
+      # Port numbers are injected into the HTML at container start via envsubst.
+      # The browser constructs the full URL using its own hostname — no host is
+      # hardcoded, so boris.local, a LAN IP, and localhost all work the same way.
+      - WEBUI_PORT=${WEBUI_PORT:-45213}
+      - MODEL_MANAGER_PORT=${MODEL_MANAGER_PORT:-45214}
+      - DOZZLE_PORT=${DOZZLE_PORT:-9999}
+
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO/dev/null http://localhost:8080/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+    logging:
+      driver: json-file
+      options:
+        max-size: "2m"
+        max-file: "2"
+        tag: "portal"
 
     networks:
       - olama_net

--- a/docker/portal/Dockerfile
+++ b/docker/portal/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:alpine
+RUN apk add --no-cache gettext
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+COPY index.html.template /tmp/index.html.template
+RUN chmod +x /entrypoint.sh
+EXPOSE 8080
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker/portal/entrypoint.sh
+++ b/docker/portal/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Inject port numbers from env vars into the HTML template at container start.
+# The HTML uses window.location.hostname so no host is hardcoded.
+set -e
+
+export WEBUI_PORT="${WEBUI_PORT:-45213}"
+export MODEL_MANAGER_PORT="${MODEL_MANAGER_PORT:-45214}"
+export DOZZLE_PORT="${DOZZLE_PORT:-9999}"
+
+envsubst '${WEBUI_PORT} ${MODEL_MANAGER_PORT} ${DOZZLE_PORT}' \
+  < /tmp/index.html.template \
+  > /usr/share/nginx/html/index.html
+
+exec "$@"

--- a/docker/portal/index.html.template
+++ b/docker/portal/index.html.template
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Olama Stack</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:         #0d0d0d;
+      --nav:        #141414;
+      --nav-border: #242424;
+      --surface:    #1a1a1a;
+      --border:     #2a2a2a;
+      --text:       #e2e2e2;
+      --dim:        #5a5a5a;
+      --accent:     #4f9eff;
+      --accent-bg:  rgba(79,158,255,.12);
+      --accent-bdr: rgba(79,158,255,.25);
+      --green:      #4ade80;
+      --red:        #f87171;
+      --yellow:     #fbbf24;
+    }
+
+    html, body {
+      height: 100%;
+      overflow: hidden;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 14px;
+    }
+
+    body { display: flex; flex-direction: column; }
+
+    /* ── Top navigation bar ───────────────────────────────────── */
+    nav {
+      height: 48px;
+      min-height: 48px;
+      background: var(--nav);
+      border-bottom: 1px solid var(--nav-border);
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      gap: .5rem;
+    }
+
+    .logo {
+      font-weight: 700;
+      font-size: .95rem;
+      letter-spacing: -.3px;
+      white-space: nowrap;
+      margin-right: .5rem;
+    }
+    .logo em { color: var(--accent); font-style: normal; }
+
+    /* ── Nav items ─────────────────────────────────────────────── */
+    .nav-group { display: flex; gap: 2px; }
+
+    .nav-item { display: flex; align-items: center; }
+
+    .nav-btn {
+      display: flex;
+      align-items: center;
+      gap: .45rem;
+      padding: .35rem .8rem;
+      border-radius: 6px 0 0 6px;
+      border: 1px solid transparent;
+      background: transparent;
+      color: var(--dim);
+      cursor: pointer;
+      font-size: .83rem;
+      transition: color .15s, background .15s;
+      white-space: nowrap;
+      line-height: 1;
+    }
+    .nav-btn svg { width: 14px; height: 14px; flex-shrink: 0; }
+    .nav-btn:hover { color: var(--text); background: rgba(255,255,255,.05); }
+    .nav-btn.active {
+      color: var(--accent);
+      background: var(--accent-bg);
+      border-color: var(--accent-bdr);
+    }
+
+    /* small "open in new tab" button, attached to the right of each nav-btn */
+    .nav-ext {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 22px;
+      height: 28px;
+      border-radius: 0 6px 6px 0;
+      border: 1px solid transparent;
+      border-left: none;
+      background: transparent;
+      color: var(--dim);
+      text-decoration: none;
+      transition: color .15s, background .15s;
+      flex-shrink: 0;
+    }
+    .nav-ext svg { width: 10px; height: 10px; }
+    .nav-ext:hover { color: var(--text); background: rgba(255,255,255,.05); }
+    .nav-btn.active + .nav-ext {
+      background: var(--accent-bg);
+      border-color: var(--accent-bdr);
+      color: var(--accent);
+    }
+
+    .nav-sep {
+      width: 1px;
+      height: 18px;
+      background: var(--border);
+      margin: 0 .5rem;
+      flex-shrink: 0;
+    }
+
+    .spacer { flex: 1; }
+
+    /* ── Status badge ──────────────────────────────────────────── */
+    .badge {
+      display: flex;
+      align-items: center;
+      gap: .4rem;
+      font-size: .73rem;
+      color: var(--dim);
+      white-space: nowrap;
+    }
+    .dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      background: var(--dim);
+      transition: background .3s;
+    }
+    .dot.ok  { background: var(--green); box-shadow: 0 0 5px var(--green); }
+    .dot.err { background: var(--red); }
+    .dot.warn { background: var(--yellow); }
+
+    /* ── Frame area ────────────────────────────────────────────── */
+    .frames {
+      flex: 1;
+      position: relative;
+      overflow: hidden;
+    }
+
+    iframe {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      border: none;
+      background: var(--bg);
+      /* hidden but kept rendered so state (open chat, scroll pos) survives tab switches */
+      visibility: hidden;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity .15s;
+    }
+    iframe.active {
+      visibility: visible;
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    /* ── Loading overlay ───────────────────────────────────────── */
+    .loader {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: .9rem;
+      background: var(--bg);
+      color: var(--dim);
+      font-size: .85rem;
+      pointer-events: none;
+      transition: opacity .25s;
+      z-index: 10;
+    }
+    .loader.gone { opacity: 0; pointer-events: none; }
+
+    .spinner {
+      width: 26px;
+      height: 26px;
+      border: 2px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin .75s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+  </style>
+</head>
+<body>
+
+<nav>
+  <div class="logo">Olama <em>Stack</em></div>
+
+  <div class="nav-group">
+
+    <!-- Chat -->
+    <div class="nav-item">
+      <button class="nav-btn active" id="btn-chat" onclick="showFrame('chat')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+        </svg>
+        Chat
+      </button>
+      <a class="nav-ext" id="ext-chat" href="#" target="_blank" title="Open Chat in new tab">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+             stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+          <polyline points="15 3 21 3 21 9"/>
+          <line x1="10" y1="14" x2="21" y2="3"/>
+        </svg>
+      </a>
+    </div>
+
+    <div class="nav-sep"></div>
+
+    <!-- Models -->
+    <div class="nav-item">
+      <button class="nav-btn" id="btn-models" onclick="showFrame('models')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+          <polyline points="7 10 12 15 17 10"/>
+          <line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>
+        Models
+      </button>
+      <a class="nav-ext" id="ext-models" href="#" target="_blank" title="Open Models in new tab">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+             stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+          <polyline points="15 3 21 3 21 9"/>
+          <line x1="10" y1="14" x2="21" y2="3"/>
+        </svg>
+      </a>
+    </div>
+
+    <div class="nav-sep"></div>
+
+    <!-- Logs -->
+    <div class="nav-item">
+      <button class="nav-btn" id="btn-logs" onclick="showFrame('logs')">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+        </svg>
+        Logs
+      </button>
+      <a class="nav-ext" id="ext-logs" href="#" target="_blank" title="Open Logs in new tab">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"
+             stroke-linecap="round" stroke-linejoin="round">
+          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+          <polyline points="15 3 21 3 21 9"/>
+          <line x1="10" y1="14" x2="21" y2="3"/>
+        </svg>
+      </a>
+    </div>
+
+  </div><!-- .nav-group -->
+
+  <div class="spacer"></div>
+
+  <div class="badge">
+    <span class="dot" id="sdot"></span>
+    <span id="stext">Connecting&hellip;</span>
+  </div>
+</nav>
+
+<div class="frames">
+  <iframe id="frame-chat"   title="Open WebUI"></iframe>
+  <iframe id="frame-models" title="Model Manager"></iframe>
+  <iframe id="frame-logs"   title="Dozzle Logs"></iframe>
+
+  <div class="loader" id="loader">
+    <div class="spinner"></div>
+    <span id="loader-msg">Loading&hellip;</span>
+  </div>
+</div>
+
+<script>
+/* ── Ports injected by envsubst at container start ─────────── */
+const PORTS = {
+  chat:   ${WEBUI_PORT},
+  models: ${MODEL_MANAGER_PORT},
+  logs:   ${DOZZLE_PORT},
+};
+
+/* ── Resolve base URL from the browser's own location ──────── */
+const proto = window.location.protocol;
+const host  = window.location.hostname;
+
+function svcUrl(key) {
+  return `${proto}//${host}:${PORTS[key]}`;
+}
+
+/* ── State ──────────────────────────────────────────────────── */
+let current = 'chat';
+const everLoaded = { chat: false, models: false, logs: false };
+
+/* ── Init ───────────────────────────────────────────────────── */
+function init() {
+  // Wire up iframes and external links
+  for (const key of Object.keys(PORTS)) {
+    const fr  = document.getElementById(`frame-${key}`);
+    const ext = document.getElementById(`ext-${key}`);
+    const url = svcUrl(key);
+
+    fr.src  = url;
+    ext.href = url;
+
+    fr.addEventListener('load',  () => frameReady(key));
+    fr.addEventListener('error', () => frameReady(key));
+  }
+
+  showFrame('chat');
+  pollStatus();
+  setInterval(pollStatus, 30000);
+}
+
+/* ── Show / hide frames ─────────────────────────────────────── */
+function showFrame(name) {
+  current = name;
+
+  // Update nav buttons
+  for (const key of Object.keys(PORTS)) {
+    document.getElementById(`btn-${key}`).classList.toggle('active', key === name);
+  }
+
+  // Show selected iframe, hide others (keep rendered — preserves chat state)
+  for (const key of Object.keys(PORTS)) {
+    document.getElementById(`frame-${key}`).classList.toggle('active', key === name);
+  }
+
+  // Show spinner until this iframe has loaded at least once
+  const loader = document.getElementById('loader');
+  if (everLoaded[name]) {
+    loader.classList.add('gone');
+  } else {
+    loader.classList.remove('gone');
+    document.getElementById('loader-msg').textContent =
+      name === 'chat'   ? 'Loading Open WebUI\u2026' :
+      name === 'models' ? 'Loading Model Manager\u2026' :
+                          'Loading Log Viewer\u2026';
+  }
+
+  // Update page title
+  document.title =
+    name === 'chat'   ? 'Chat \u2014 Olama Stack' :
+    name === 'models' ? 'Models \u2014 Olama Stack' :
+                        'Logs \u2014 Olama Stack';
+}
+
+function frameReady(name) {
+  everLoaded[name] = true;
+  if (current === name) {
+    document.getElementById('loader').classList.add('gone');
+  }
+}
+
+/* ── Status: ping model-manager for installed model count ───── */
+async function pollStatus() {
+  try {
+    const r = await fetch(`${svcUrl('models')}/api/local`,
+      { signal: AbortSignal.timeout(5000) });
+    if (!r.ok) throw new Error();
+    const d = await r.json();
+    const n = (d.models || []).length;
+    setStatus('ok', `${n} model${n !== 1 ? 's' : ''} installed`);
+  } catch {
+    setStatus('warn', 'Services starting\u2026');
+  }
+}
+
+function setStatus(state, text) {
+  document.getElementById('sdot').className = `dot ${state}`;
+  document.getElementById('stext').textContent = text;
+}
+
+init();
+</script>
+</body>
+</html>

--- a/docker/portal/nginx.conf
+++ b/docker/portal/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # Never cache the portal shell — ports may change on reinstall
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+    }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -49,6 +49,7 @@ REPO_GIT="https://github.com/Crashcart/Olama-intelgpu"
 REPO_BRANCH="${REPO_BRANCH:-}"
 DOZZLE_PORT="${DOZZLE_PORT:-9999}"
 MODEL_MANAGER_PORT="${MODEL_MANAGER_PORT:-45214}"
+PORTAL_PORT="${PORTAL_PORT:-45200}"
 COMPOSE_PROJECT="olama"
 RECREATE_CONTAINERS=false
 
@@ -298,6 +299,7 @@ _stamp_env "$ENV_FILE" \
   WEBUI_PORT           "${WEBUI_PORT}" \
   DOZZLE_PORT          "${DOZZLE_PORT}" \
   MODEL_MANAGER_PORT   "${MODEL_MANAGER_PORT}" \
+  PORTAL_PORT          "${PORTAL_PORT}" \
   OLLAMA_VERSION       "${OLLAMA_VERSION}" \
   VIDEO_GID            "${VIDEO_GID}" \
   RENDER_GID           "${RENDER_GID}"
@@ -311,8 +313,8 @@ info "Review and adjust ${ENV_FILE} at any time — then run: docker compose up 
 # devices on the same network can connect.
 sep
 info "Checking host firewall for LAN access..."
-_fw_ports=("${WEBUI_PORT}" "${OLLAMA_PORT}" "${DOZZLE_PORT}" "${MODEL_MANAGER_PORT}")
-_fw_labels=("Open WebUI (chat)" "Ollama API" "Dozzle (logs)" "Model Manager")
+_fw_ports=("${PORTAL_PORT}" "${WEBUI_PORT}" "${MODEL_MANAGER_PORT}" "${OLLAMA_PORT}" "${DOZZLE_PORT}")
+_fw_labels=("Portal (unified UI)" "Open WebUI (chat)" "Model Manager" "Ollama API" "Dozzle (logs)")
 _fw_opened=()
 
 if command -v ufw &>/dev/null && ufw status 2>/dev/null | grep -q "Status: active"; then
@@ -383,7 +385,7 @@ for svc in open-webui searxng pipelines dozzle; do
 done
 
 # Locally-built images (no registry — must use build, not pull)
-for svc in model-manager; do
+for svc in model-manager portal; do
   cname="olama-${svc}"
   if $RECREATE_CONTAINERS; then
     info "  $cname — --recreate set, rebuilding image..."
@@ -400,7 +402,7 @@ done
 
 # ── Start the full stack ───────────────────────────────────────────────────────
 sep
-info "Starting Olama stack (6 containers)..."
+info "Starting Olama stack (7 containers)..."
 if $RECREATE_CONTAINERS; then
   info "(--recreate: existing containers will be replaced)"
   $COMPOSE_CMD up -d --force-recreate
@@ -445,16 +447,21 @@ _lan_ip=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i==
 sep
 success "Olama stack is running!"
 echo
-echo "  Chat UI        :  http://localhost:${WEBUI_PORT}"
-echo "  Model Manager  :  http://localhost:${MODEL_MANAGER_PORT}  (search, download, delete models)"
-echo "  Ollama API     :  http://localhost:${OLLAMA_PORT}"
-echo "  Log viewer     :  http://localhost:${DOZZLE_PORT}  (Dozzle — live logs for all containers)"
+echo "  ┌─ Unified portal (recommended bookmark) ──────────────────────┐"
+echo "  │  http://localhost:${PORTAL_PORT}   (Chat + Models + Logs in one page)  │"
+echo "  └───────────────────────────────────────────────────────────────┘"
+echo
+echo "  Individual services:"
+echo "    Chat UI        →  http://localhost:${WEBUI_PORT}"
+echo "    Model Manager  →  http://localhost:${MODEL_MANAGER_PORT}"
+echo "    Log viewer     →  http://localhost:${DOZZLE_PORT}"
+echo "    Ollama API     →  http://localhost:${OLLAMA_PORT}"
 if [[ -n "$_lan_ip" ]]; then
   echo
   echo "  From other devices on your network:"
+  echo "    Portal         →  http://${_lan_ip}:${PORTAL_PORT}   ← bookmark this"
   echo "    Chat UI        →  http://${_lan_ip}:${WEBUI_PORT}"
   echo "    Model Manager  →  http://${_lan_ip}:${MODEL_MANAGER_PORT}"
-  echo "    Ollama API     →  http://${_lan_ip}:${OLLAMA_PORT}"
   echo "    Log viewer     →  http://${_lan_ip}:${DOZZLE_PORT}"
 fi
 echo
@@ -464,13 +471,7 @@ echo "  Status      :  bash ${INSTALL_DIR}/scripts/logs.sh status"
 echo "  Update UI   :  bash ${INSTALL_DIR}/scripts/update.sh"
 echo "  Stop        :  cd ${INSTALL_DIR}/docker && docker compose down"
 echo
-echo "  Pull a model (via Model Manager UI or CLI):"
-echo "    open  http://localhost:${MODEL_MANAGER_PORT}  (recommended — search, filter, one-click pull)"
-echo "    or:   docker exec olama ollama pull mistral"
-echo "          docker exec olama ollama pull llama3.2:3b"
-echo "          docker exec olama ollama pull llava          # vision model"
-echo
-echo "  If Open WebUI shows 'Ollama is running' instead of the chat UI:"
+echo "  If Open WebUI shows a blank page or 'Ollama is running':"
 echo "    bash ${INSTALL_DIR}/scripts/update.sh"
 echo
 echo "  Verify Intel GPU is in use (after pulling a model):"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -53,11 +53,11 @@ warn()    { echo -e "${YELLOW}[update]${NC} $*"; }
 
 # ── Choose which services to update ──────────────────────────────────────────
 if $UPDATE_ALL; then
-  SERVICES=(open-webui model-manager pipelines searxng dozzle)
+  SERVICES=(open-webui model-manager portal pipelines searxng dozzle)
   info "Updating all services..."
 else
-  SERVICES=(open-webui model-manager)
-  info "Updating UI services (open-webui, model-manager)..."
+  SERVICES=(open-webui model-manager portal)
+  info "Updating UI services (open-webui, model-manager, portal)..."
   info "Use --all to also update searxng, pipelines, and dozzle."
 fi
 


### PR DESCRIPTION
Adds a new nginx:alpine container (olama-portal, port 45200) that wraps Open WebUI, Model Manager, and Dozzle into a single-page portal with a 48 px dark nav bar.  Iframes remain rendered when switching tabs so chat state and scroll position are never lost.  Port numbers are injected via envsubst at container start so the image works on any hostname without reconfiguration.

- docker/portal/: Dockerfile, nginx.conf, entrypoint.sh, index.html.template
- docker/docker-compose.yml: portal service with healthcheck and depends_on
- scripts/install.sh: PORTAL_PORT default, firewall rule, build step, banner
- scripts/update.sh: portal added to default and --all update lists
- README.md: portal documented as recommended bookmark (port 45200)

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6