### PR TITLE
feat(portal): hide Crit Issues button when healthy; richer error diag…

### DIFF
--- a/docker/model-manager/main.py
+++ b/docker/model-manager/main.py
@@ -174,6 +174,46 @@ async def get_config():
     return {"webui_port": WEBUI_PORT}
 
 
+@app.get("/api/health")
+async def health_check():
+    """Detailed Ollama connectivity diagnostic for the portal health panel."""
+    import time
+    result: dict = {
+        "ollama": {
+            "url": OLLAMA_URL,
+            "ok": False,
+            "version": None,
+            "latency_ms": None,
+            "error": None,
+            "error_type": None,
+        }
+    }
+    t0 = time.monotonic()
+    try:
+        async with httpx.AsyncClient(timeout=8) as client:
+            resp = await client.get(f"{OLLAMA_URL}/api/version")
+            result["ollama"]["latency_ms"] = round((time.monotonic() - t0) * 1000)
+            resp.raise_for_status()
+            result["ollama"]["ok"] = True
+            try:
+                result["ollama"]["version"] = resp.json().get("version")
+            except Exception:
+                pass
+    except httpx.ConnectError as e:
+        result["ollama"]["latency_ms"] = round((time.monotonic() - t0) * 1000)
+        result["ollama"]["error"] = str(e)
+        result["ollama"]["error_type"] = "ConnectError"
+    except httpx.TimeoutException:
+        result["ollama"]["latency_ms"] = round((time.monotonic() - t0) * 1000)
+        result["ollama"]["error"] = f"Connection timed out after 8 s (url: {OLLAMA_URL})"
+        result["ollama"]["error_type"] = "Timeout"
+    except Exception as exc:
+        result["ollama"]["latency_ms"] = round((time.monotonic() - t0) * 1000)
+        result["ollama"]["error"] = str(exc)
+        result["ollama"]["error_type"] = type(exc).__name__
+    return result
+
+
 @app.get("/api/catalog")
 async def catalog():
     return {"models": CATALOG}

--- a/docker/portal/index.html.template
+++ b/docker/portal/index.html.template
@@ -84,7 +84,9 @@
       border-color: var(--accent-bdr);
     }
 
-    /* Crit Issues button: always red */
+    /* Crit Issues button: always red; hidden until an error is found */
+    #issues-nav-wrap { display: none; align-items: center; gap: 2px; }
+    #issues-nav-wrap.visible { display: flex; }
     #btn-issues { color: var(--red); }
     #btn-issues:hover { color: var(--red); background: rgba(248,113,113,.07); }
     #btn-issues.active {
@@ -288,6 +290,16 @@
       font-size: .78rem;
       color: var(--dim);
       flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: .2rem;
+    }
+    .svc-detail-sub {
+      font-size: .72rem;
+      color: var(--red);
+      opacity: .8;
+      font-family: monospace;
+      word-break: break-all;
     }
     .svc-port {
       font-size: .72rem;
@@ -306,9 +318,13 @@
     .issues-summary.err { background: rgba(248,113,113,.08); border: 1px solid rgba(248,113,113,.2); color: var(--red); }
     .issues-summary.checking { background: var(--surface); border: 1px solid var(--border); color: var(--dim); }
 
-    .refresh-btn {
+    .issues-actions {
+      display: flex;
+      gap: .5rem;
       margin-top: .75rem;
-      width: 100%;
+    }
+    .refresh-btn {
+      flex: 1;
       padding: .45rem;
       border-radius: 6px;
       border: 1px solid var(--border);
@@ -319,6 +335,19 @@
       transition: color .15s, background .15s;
     }
     .refresh-btn:hover { color: var(--text); background: rgba(255,255,255,.05); }
+    .copy-btn {
+      padding: .45rem .9rem;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--dim);
+      font-size: .78rem;
+      cursor: pointer;
+      transition: color .15s, background .15s;
+      white-space: nowrap;
+    }
+    .copy-btn:hover { color: var(--text); background: rgba(255,255,255,.05); }
+    .copy-btn.copied { color: var(--green); border-color: rgba(74,222,128,.3); }
   </style>
 </head>
 <body>
@@ -391,19 +420,20 @@
       </a>
     </div>
 
-    <div class="nav-sep"></div>
-
-    <!-- Crit Issues -->
-    <div class="nav-item">
-      <button class="nav-btn" id="btn-issues" onclick="showFrame('issues')">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-             stroke-linecap="round" stroke-linejoin="round">
-          <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
-          <line x1="12" y1="9" x2="12" y2="13"/>
-          <line x1="12" y1="17" x2="12.01" y2="17"/>
-        </svg>
-        Crit Issues
-      </button>
+    <!-- Crit Issues: hidden until errors detected -->
+    <div id="issues-nav-wrap">
+      <div class="nav-sep"></div>
+      <div class="nav-item">
+        <button class="nav-btn" id="btn-issues" onclick="showFrame('issues')">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+               stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+          Crit Issues
+        </button>
+      </div>
     </div>
 
   </div><!-- .nav-group -->
@@ -432,7 +462,10 @@
         <!-- rows injected by JS -->
       </div>
       <div class="issues-summary checking" id="issues-summary">Checking&hellip;</div>
-      <button class="refresh-btn" onclick="runHealthCheck()">Refresh now</button>
+      <div class="issues-actions">
+        <button class="refresh-btn" onclick="runHealthCheck()">Refresh now</button>
+        <button class="copy-btn" id="copy-btn" onclick="copyDiagnostic()">Copy diagnostic</button>
+      </div>
     </div>
   </div>
 
@@ -552,48 +585,80 @@ function setStatus(state, text) {
 }
 
 /* ── Health check (Issues panel) ───────────────────────────── */
+// Ollama is checked via /api/health (CORS-safe, returns detailed diagnostics).
+// UI-only services use no-cors fetch — opaque response = up, throw = down.
 const SERVICES = [
-  { id: 'ollama',  name: 'Ollama API',    port: null,         path: '/api/local', cors: true  },
-  { id: 'webui',   name: 'Open WebUI',    port: PORTS.chat,   path: '/',          cors: false },
-  { id: 'manager', name: 'Model Manager', port: PORTS.models, path: '/',          cors: false },
-  { id: 'dozzle',  name: 'Log Viewer',    port: PORTS.logs,   path: '/',          cors: false },
+  { id: 'ollama',  name: 'Ollama API',    port: null,         path: '/api/health', mode: 'health' },
+  { id: 'webui',   name: 'Open WebUI',    port: PORTS.chat,   path: '/',           mode: 'nocors' },
+  { id: 'manager', name: 'Model Manager', port: PORTS.models, path: '/',           mode: 'nocors' },
+  { id: 'dozzle',  name: 'Log Viewer',    port: PORTS.logs,   path: '/',           mode: 'nocors' },
 ];
 
 let lastCheckResults = {};
 
 async function checkService(svc) {
-  const url = svc.cors
-    ? `${svcUrl('models')}${svc.path}`           // model-manager JSON endpoint
+  const url = svc.mode === 'health'
+    ? `${svcUrl('models')}${svc.path}`
     : `${proto}//${host}:${svc.port}${svc.path}`;
+  const t0 = Date.now();
+
   try {
-    if (svc.cors) {
-      const r = await fetch(url, { signal: AbortSignal.timeout(6000) });
-      if (!r.ok) return { state: 'err', detail: `HTTP ${r.status}` };
+    if (svc.mode === 'health') {
+      // model-manager /api/health — returns detailed Ollama diagnostics
+      const r = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      const latency = Date.now() - t0;
+      if (!r.ok) {
+        let body = '';
+        try { body = await r.text(); } catch {}
+        let msg = `HTTP ${r.status}`;
+        try { const j = JSON.parse(body); if (j.detail) msg = j.detail; } catch {}
+        return { state: 'err', detail: msg, diagnostic: `URL: ${url}\nStatus: ${r.status} ${r.statusText}\nBody: ${body.slice(0, 400)}`, latency_ms: latency };
+      }
       const d = await r.json();
-      const n = (d.models || []).length;
-      return { state: 'ok', detail: `${n} model${n !== 1 ? 's' : ''} loaded` };
+      if (!d.ollama.ok) {
+        return {
+          state: 'err',
+          detail: d.ollama.error_type || 'Not reachable',
+          diagnostic: [
+            `URL checked: ${d.ollama.url}/api/version`,
+            `Error type: ${d.ollama.error_type}`,
+            `Error: ${d.ollama.error}`,
+            `Latency: ${d.ollama.latency_ms} ms`,
+          ].join('\n'),
+          latency_ms: d.ollama.latency_ms,
+        };
+      }
+      return {
+        state: 'ok',
+        detail: `v${d.ollama.version || '?'} · ${d.ollama.latency_ms} ms`,
+        latency_ms: d.ollama.latency_ms,
+      };
+
     } else {
-      // no-cors: any response (even opaque) means the server is up;
-      // a throw means connection refused / timeout.
+      // no-cors: opaque success = up; throw = down
       await fetch(url, { mode: 'no-cors', signal: AbortSignal.timeout(6000) });
-      return { state: 'ok', detail: 'Responding' };
+      return { state: 'ok', detail: `Responding · ${Date.now() - t0} ms` };
     }
-  } catch {
-    return { state: 'err', detail: 'Not reachable' };
+
+  } catch (e) {
+    const latency = Date.now() - t0;
+    const isTimeout = e.name === 'TimeoutError' || e.name === 'AbortError';
+    return {
+      state: 'err',
+      detail: isTimeout ? `Timed out (${latency} ms)` : 'Connection refused',
+      diagnostic: `URL: ${url}\nError: ${e.name}: ${e.message}`,
+      latency_ms: latency,
+    };
   }
 }
 
 async function runHealthCheck() {
-  // Render skeleton rows immediately
   renderRows(SERVICES.map(s => ({ ...s, state: 'checking', detail: '' })));
   document.getElementById('issues-summary').className = 'issues-summary checking';
   document.getElementById('issues-summary').textContent = 'Checking\u2026';
 
-  // Run all checks in parallel
   const results = await Promise.all(SERVICES.map(checkService));
-
   results.forEach((res, i) => { lastCheckResults[SERVICES[i].id] = res; });
-
   renderRows(SERVICES.map((s, i) => ({ ...s, ...results[i] })));
 
   const anyErr = results.some(r => r.state === 'err');
@@ -606,11 +671,19 @@ async function runHealthCheck() {
     sum.textContent = 'All systems nominal.';
   }
 
-  // Update Issues button colour
+  // Show/hide the Issues button based on whether errors exist
+  const issNav = document.getElementById('issues-nav-wrap');
   const issBtn = document.getElementById('btn-issues');
-  issBtn.classList.toggle('issues-err', anyErr);
+  if (anyErr) {
+    issNav.classList.add('visible');
+    issBtn.classList.add('issues-err');
+  } else {
+    issNav.classList.remove('visible');
+    issBtn.classList.remove('issues-err');
+    // If we're viewing the issues panel and everything resolved, go back to chat
+    if (current === 'issues') showFrame('chat');
+  }
 
-  // Timestamp
   const now = new Date();
   document.getElementById('issues-updated').textContent =
     `Last checked ${now.getHours().toString().padStart(2,'0')}:${now.getMinutes().toString().padStart(2,'0')}:${now.getSeconds().toString().padStart(2,'0')}`;
@@ -618,13 +691,50 @@ async function runHealthCheck() {
 
 function renderRows(rows) {
   const list = document.getElementById('svc-list');
-  list.innerHTML = rows.map(s => `
+  list.innerHTML = rows.map(s => {
+    const sub = s.state === 'err' && s.diagnostic
+      ? `<span class="svc-detail-sub">${s.diagnostic.replace(/\n/g, ' &nbsp;|&nbsp; ')}</span>`
+      : '';
+    return `
     <div class="svc-row">
       <span class="svc-dot ${s.state || 'checking'}"></span>
       <span class="svc-name">${s.name}</span>
-      <span class="svc-detail">${s.detail || ''}</span>
+      <span class="svc-detail"><span>${s.detail || ''}</span>${sub}</span>
       ${s.port ? `<span class="svc-port">:${s.port}</span>` : ''}
-    </div>`).join('');
+    </div>`;
+  }).join('');
+}
+
+async function copyDiagnostic() {
+  const lines = [
+    'Olama Stack — Diagnostic Report',
+    `Generated : ${new Date().toISOString()}`,
+    `Portal URL: ${window.location.href}`,
+    `User-Agent: ${navigator.userAgent}`,
+    '',
+  ];
+  for (const svc of SERVICES) {
+    const res = lastCheckResults[svc.id];
+    if (!res) continue;
+    lines.push(`[${svc.name}]`);
+    lines.push(`  Status : ${res.state}`);
+    lines.push(`  Detail : ${res.detail || '—'}`);
+    if (res.latency_ms != null) lines.push(`  Latency: ${res.latency_ms} ms`);
+    if (res.diagnostic) {
+      for (const l of res.diagnostic.split('\n')) lines.push(`  ${l}`);
+    }
+    lines.push('');
+  }
+  try {
+    await navigator.clipboard.writeText(lines.join('\n'));
+    const btn = document.getElementById('copy-btn');
+    btn.textContent = 'Copied!';
+    btn.classList.add('copied');
+    setTimeout(() => { btn.textContent = 'Copy diagnostic'; btn.classList.remove('copied'); }, 2000);
+  } catch {
+    // Fallback for browsers that block clipboard without interaction
+    prompt('Copy the diagnostic report below:', lines.join('\n'));
+  }
 }
 
 init();


### PR DESCRIPTION
…nostics

- Crit Issues nav button is now hidden until a health check detects an error, and disappears again (returning to Chat view) once all services recover.
- Health checks now use a new /api/health endpoint on the model-manager that hits Ollama's /api/version with timing, returning error_type + full error message — so "Ollama API Not reachable" becomes e.g. "ConnectError: All connection attempts failed (olama:11434)" with latency in ms.
- no-cors checks (WebUI, Models, Logs) now show round-trip time on success and distinguish timeout vs connection-refused on failure.
- "Copy diagnostic" button on the issues panel assembles a structured text report (URL, error type, raw message, latency, browser info) ready to paste for debugging.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6