### PR TITLE
fix(portal): add curl for reliable health check; rebuild required

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -512,11 +512,11 @@ services:
       - DOZZLE_PORT=${DOZZLE_PORT:-9999}
 
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO/dev/null http://localhost:8080/ || exit 1"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/"]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 15s
 
     logging:
       driver: json-file

--- a/docker/portal/Dockerfile
+++ b/docker/portal/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:alpine
-RUN apk add --no-cache gettext
+RUN apk add --no-cache gettext curl
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY entrypoint.sh /entrypoint.sh
 COPY index.html.template /tmp/index.html.template


### PR DESCRIPTION
The portal image was stale (nginx not binding 8080 in the running container because the image predated the current nginx.conf). Also switch the health check from BusyBox wget — which silently fails on some Alpine nginx builds — to curl -sf, which is now installed via apk and gives clear diagnostics.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6