### PR TITLE
fix(update): rebuild portal image + fix stale health-check diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,17 +242,22 @@ docker builder prune --all
 
 ## Upgrading Containers
 
-Use `scripts/update.sh` to pull fresh images for the UI services and fix the "Ollama is running" blank-page issue:
+Use `scripts/update.sh` to pull fresh images and rebuild local services:
 
 ```bash
-# Update open-webui and model-manager (most common)
+# Update open-webui, model-manager, and portal (most common)
 bash /opt/olama-stack/scripts/update.sh
 
 # Update every service including searxng, pipelines, dozzle
 bash /opt/olama-stack/scripts/update.sh --all
 ```
 
-The script pulls the latest images, rebuilds any locally-built containers, and recreates the affected containers. All data is preserved.
+The script:
+1. Pulls the latest registry images (`open-webui`, `searxng`, `pipelines`, `dozzle`)
+2. **Rebuilds locally-built images from source** (`model-manager`, `portal`) with `--pull --no-cache`
+3. Recreates the updated containers; all data is preserved
+
+> **Always include `portal` in updates.** The portal's diagnostic health-check page is baked into the image at build time. Running `update.sh` ensures it is always in sync with the current `model-manager` API.
 
 To upgrade the entire stack from scratch:
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -3,15 +3,15 @@
 # update.sh — Update the Olama stack to the latest images
 #
 # Usage:
-#   bash scripts/update.sh           # update open-webui + model-manager only
+#   bash scripts/update.sh           # update open-webui + model-manager + portal
 #   bash scripts/update.sh --all     # update every service
 #
 # What this does:
-#   1. Pulls the latest image for each updated service
-#   2. Recreates only the containers whose image changed
-#   3. Leaves all data (chat history, models, config) untouched
+#   1. Pulls latest registry images (open-webui, searxng, pipelines, dozzle)
+#   2. Rebuilds locally-built images (model-manager, portal) from source
+#   3. Recreates updated containers; all data (chat history, models) is preserved
 #
-# Safe to run while the stack is running — containers are replaced one at a time.
+# Safe to run while the stack is running.
 # =============================================================================
 set -euo pipefail
 
@@ -39,7 +39,7 @@ while [[ $# -gt 0 ]]; do
     --help|-h)
       echo "Usage: $0 [--all]"
       echo ""
-      echo "  (no flags)  Update open-webui and model-manager (the UI services)"
+      echo "  (no flags)  Update open-webui, model-manager, and portal (the UI services)"
       echo "  --all       Update every service including searxng, pipelines, dozzle"
       exit 0 ;;
     *) echo "Unknown option: $1"; shift ;;
@@ -51,59 +51,59 @@ info()    { echo -e "${CYAN}[update]${NC} $*"; }
 success() { echo -e "${GREEN}[update]${NC} $*"; }
 warn()    { echo -e "${YELLOW}[update]${NC} $*"; }
 
-# ── Choose which services to update ──────────────────────────────────────────
+# ── Classify services ─────────────────────────────────────────────────────────
+# LOCAL_BUILDS  — have a local Dockerfile; must be rebuilt (not pulled)
+# REGISTRY_SVCS — pulled from a public registry
 if $UPDATE_ALL; then
-  SERVICES=(open-webui model-manager portal pipelines searxng dozzle)
+  LOCAL_BUILDS=(model-manager portal)
+  REGISTRY_SVCS=(open-webui pipelines searxng dozzle)
+  ALL_SERVICES=(open-webui model-manager portal pipelines searxng dozzle)
   info "Updating all services..."
 else
-  SERVICES=(open-webui model-manager portal)
+  LOCAL_BUILDS=(model-manager portal)
+  REGISTRY_SVCS=(open-webui)
+  ALL_SERVICES=(open-webui model-manager portal)
   info "Updating UI services (open-webui, model-manager, portal)..."
   info "Use --all to also update searxng, pipelines, and dozzle."
 fi
-
 echo ""
 
-# ── Pull registry images / rebuild local images ───────────────────────────────
-# model-manager is built from a local Dockerfile — skip pull, go straight to build.
-REGISTRY_SERVICES=()
-for svc in "${SERVICES[@]}"; do
-  [[ "$svc" == "model-manager" ]] && continue
-  REGISTRY_SERVICES+=("$svc")
+# ── Pull registry images ──────────────────────────────────────────────────────
+for svc in "${REGISTRY_SVCS[@]}"; do
+  info "Pulling latest image for: ${svc}"
+  COMPOSE_ANSI=never $COMPOSE pull "$svc" 2>&1 \
+    | grep -v "^#" \
+    | sed 's/^/  /'
+  success "${svc} — image ready."
+  echo ""
 done
 
-if [[ ${#REGISTRY_SERVICES[@]} -gt 0 ]]; then
-  for svc in "${REGISTRY_SERVICES[@]}"; do
-    info "Pulling latest image for: ${svc}"
-    COMPOSE_ANSI=never $COMPOSE pull "$svc" 2>&1 \
-      | grep -v "^#" \
-      | sed 's/^/  /'
-    success "${svc} — image ready."
-    echo ""
-  done
-fi
-
-# model-manager is always rebuilt (local Dockerfile)
-info "Rebuilding model-manager image..."
-COMPOSE_ANSI=never $COMPOSE build --pull --no-cache --progress plain model-manager \
-  | grep -v "^#" \
-  | sed 's/^/  /'
-success "model-manager image rebuilt."
-echo ""
+# ── Rebuild local images ──────────────────────────────────────────────────────
+# --pull  : refresh the base image (nginx:alpine, python:*) while building
+# --no-cache: ensure the latest source files are copied in (template changes etc.)
+for svc in "${LOCAL_BUILDS[@]}"; do
+  info "Rebuilding ${svc} image from source..."
+  COMPOSE_ANSI=never $COMPOSE build --pull --no-cache --progress plain "$svc" \
+    | grep -v "^#" \
+    | sed 's/^/  /'
+  success "${svc} image rebuilt."
+  echo ""
+done
 
 # ── Recreate updated containers ───────────────────────────────────────────────
 info "Recreating updated containers (data is preserved)..."
-COMPOSE_ANSI=never $COMPOSE up -d --force-recreate "${SERVICES[@]}"
+COMPOSE_ANSI=never $COMPOSE up -d --force-recreate "${ALL_SERVICES[@]}"
 echo ""
 
 # ── Done ──────────────────────────────────────────────────────────────────────
-# Read ports from .env (or fall back to defaults)
-WEBUI_PORT=$(grep -E '^WEBUI_PORT=' .env 2>/dev/null | cut -d= -f2 || echo 45213)
-WEBUI_PORT=${WEBUI_PORT:-45213}
-MODEL_MANAGER_PORT=$(grep -E '^MODEL_MANAGER_PORT=' .env 2>/dev/null | cut -d= -f2 || echo 45214)
-MODEL_MANAGER_PORT=${MODEL_MANAGER_PORT:-45214}
+_env_read() { grep -E "^${1}=" .env 2>/dev/null | tail -1 | cut -d= -f2 || echo "${2}"; }
+PORTAL_PORT=$(_env_read PORTAL_PORT 45200)
+WEBUI_PORT=$(_env_read WEBUI_PORT 45213)
+MODEL_MANAGER_PORT=$(_env_read MODEL_MANAGER_PORT 45214)
 
 success "Update complete!"
 echo ""
+echo "  Portal         →  http://localhost:${PORTAL_PORT}"
 echo "  Chat UI        →  http://localhost:${WEBUI_PORT}"
 echo "  Model Manager  →  http://localhost:${MODEL_MANAGER_PORT}"
 echo ""


### PR DESCRIPTION
The portal container was never getting a fresh image on update runs because update.sh classified it as a registry service and called `docker compose pull portal` — which silently does nothing for a locally-built image.  The result is stale HTML served indefinitely, giving users a confusing old diagnostic page (wrong service names, no proper Ollama error detail, misleading "Connection refused" errors from a missing CORS header that was already fixed in model-manager).

Changes to update.sh:
- Introduce LOCAL_BUILDS list (model-manager, portal) that are rebuilt with `docker compose build --pull --no-cache` on every update run
- REGISTRY_SVCS (open-webui, searxng, pipelines, dozzle) are still pulled; portal is removed from that list
- `portal` is now rebuilt in the default (no-flag) update, not just --all
- Done summary now also prints the Portal URL

Changes to README:
- Document that portal is always included and explain why
- Note that update.sh rebuilds from source for local images

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6