### PR TITLE
fix: revert GitHub repo URL to Olama-intelgpu — repo not yet renamed …

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The fastest way to get the full stack running. Clones the repo, installs Docker 
 **Step 1 — Run the installer**
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/main/scripts/install.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/main/scripts/install.sh)
 ```
 
 The installer will:
@@ -125,7 +125,7 @@ The stack binds to `0.0.0.0` so it is reachable on **all network interfaces and 
 ## Installer Options
 
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/main/scripts/install.sh) [OPTIONS]
+bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/main/scripts/install.sh) [OPTIONS]
 ```
 
 | Flag | Default | Purpose |
@@ -215,8 +215,8 @@ The stack is designed to work across subnets out of the box:
 **Step 1 — Clone the repository**
 
 ```bash
-git clone https://github.com/Crashcart/Ollama-intelgpu.git
-cd Ollama-intelgpu
+git clone https://github.com/Crashcart/Olama-intelgpu.git
+cd Olama-intelgpu
 ```
 
 **Step 2 — Configure environment**
@@ -277,7 +277,7 @@ bash /opt/ollama-stack/scripts/uninstall.sh
 bash /opt/ollama-stack/scripts/uninstall.sh --purge
 
 # Uninstall from a machine where the repo was never cloned (one-liner)
-bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/main/scripts/uninstall.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/main/scripts/uninstall.sh)
 ```
 
 **Options:**
@@ -510,7 +510,7 @@ You (toggle ON) → Open WebUI → SearXNG → Public search engines
 
 1. In Runtipi settings → **App Stores**, add:
    ```
-   https://github.com/Crashcart/Ollama-intelgpu
+   https://github.com/Crashcart/Olama-intelgpu
    ```
 2. **Ollama (Intel GPU)** will appear in your store.
 3. Install it, then pull a model:
@@ -529,7 +529,7 @@ Copy `runtipi/apps/ollama-intel-gpu/` into your Runtipi `apps/` directory and re
 ## Directory Structure
 
 ```
-Ollama-intelgpu/
+Olama-intelgpu/
 ├── docker/
 │   ├── Dockerfile               # Ollama + Intel oneAPI GPU drivers
 │   ├── docker-compose.yml       # Full stack: portal + ollama + open-webui + model-manager + searxng + pipelines + dozzle

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,10 +6,10 @@
 #   bash scripts/install.sh [OPTIONS]
 #
 # Usage (one-liner curl pipe — repo must be public):
-#   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/main/scripts/install.sh) [OPTIONS]
+#   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/main/scripts/install.sh) [OPTIONS]
 #
 #   If main branch is not yet available (e.g. PR not merged), target the branch:
-#   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/<branch>/scripts/install.sh) --branch <branch>
+#   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/<branch>/scripts/install.sh) --branch <branch>
 #
 # Options:
 #   --data-dir  DIR   Where to store models, chat history, config (default: /opt/ollama)
@@ -44,7 +44,7 @@ DATA_DIR="${DATA_DIR:-/opt/ollama}"
 OLLAMA_PORT="${OLLAMA_PORT:-11434}"
 WEBUI_PORT="${WEBUI_PORT:-45213}"
 OLLAMA_VERSION="${OLLAMA_VERSION:-latest}"
-REPO_GIT="https://github.com/Crashcart/Ollama-intelgpu"
+REPO_GIT="https://github.com/Crashcart/Olama-intelgpu"
 # Branch is auto-detected below; override with --branch or the REPO_BRANCH env var.
 REPO_BRANCH="${REPO_BRANCH:-}"
 DOZZLE_PORT="${DOZZLE_PORT:-9999}"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -3,7 +3,7 @@
 # uninstall.sh — Remove the Ollama Intel GPU stack
 #
 # One-liner (mirrors install.sh — no local clone required):
-#   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/main/scripts/uninstall.sh)
+#   bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/main/scripts/uninstall.sh)
 #
 # From a local clone:
 #   bash scripts/uninstall.sh [OPTIONS]
@@ -435,7 +435,7 @@ if ! $PURGE_DATA && [[ -d "$DATA_DIR" ]]; then
   echo    "    └── memory/     — AI memory store"
   echo
   echo    "  To delete it now:  sudo rm -rf ${DATA_DIR}"
-  echo    "  To reinstall:      bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Ollama-intelgpu/main/scripts/install.sh)"
+  echo    "  To reinstall:      bash <(curl -fsSL https://raw.githubusercontent.com/Crashcart/Olama-intelgpu/main/scripts/install.sh)"
   echo
 fi
 


### PR DESCRIPTION
…on GitHub

The bulk rename changed Crashcart/Olama-intelgpu → Crashcart/Ollama-intelgpu in install script and README URLs, but the actual GitHub repository is still named Olama-intelgpu causing 404 on curl install.

Reverts only the GitHub URL references (repo name in raw.githubusercontent.com and github.com links) back to Olama-intelgpu to match the live repo. All internal stack names (containers, images, paths) remain correctly renamed to ollama-*.

To complete the rename: go to github.com/Crashcart/Olama-intelgpu → Settings → rename to Ollama-intelgpu, then update these URLs again.

https://claude.ai/code/session_01Cuu7kRydiSgTsTAsfGFKa6